### PR TITLE
fix big-endian issue and add test steps for validation

### DIFF
--- a/ozstream_impl.hpp
+++ b/ozstream_impl.hpp
@@ -207,8 +207,8 @@ void basic_gzip_ostream<Elem, Tr, ElemA, ByteT, ByteAT>::add_header() {
 template<typename Elem, typename Tr, typename ElemA, typename ByteT,
 		typename ByteAT>
 void basic_gzip_ostream<Elem, Tr, ElemA, ByteT, ByteAT>::add_footer() {
-	put_long(this->rdbuf()->get_ostream(), this->rdbuf()->get_crc());
-	put_long(this->rdbuf()->get_ostream(), this->rdbuf()->get_in_size());
+	put_long(this->rdbuf()->get_ostream(), htole32(this->rdbuf()->get_crc()));
+	put_long(this->rdbuf()->get_ostream(), htole32(this->rdbuf()->get_in_size()));
 }
 
 } // zstream

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,2 @@
+all:
+	g++ -I.. -o output_test output_test.cpp -lz

--- a/test/big_endian/README.md
+++ b/test/big_endian/README.md
@@ -1,0 +1,11 @@
+# Setup Big Endian Environment
+
+These steps have been test on Ubuntu 22.04.  
+
+* ./powerpc_sysroot_setup.sh
+  * This setups up a big endian build and run environment
+  * Uses Debian Jesse distribution that supported powerpc big endian architectures
+* ./build.sh
+  * build output_test under big endian envirionment
+* ./run_test.sh
+  * runs output_test under big endian envirionment

--- a/test/big_endian/build.sh
+++ b/test/big_endian/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+SYSROOT=${HOME}/powerpc_sysroot
+
+sudo cp -r ../../../zstream-cpp ${SYSROOT}
+sudo chroot ${SYSROOT} /bin/bash -c "cd zstream-cpp/test && make"

--- a/test/big_endian/powerpc_sysroot_setup.sh
+++ b/test/big_endian/powerpc_sysroot_setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# 
+# Setups up powerpc sysroot on Ubuntu 22.04
+#
+set -e
+
+sudo apt install -y qemu-user-static debootstrap
+SYSROOT=${HOME}/powerpc_sysroot
+mkdir -p ${SYSROOT}
+sudo debootstrap --arch=powerpc --foreign \
+    jessie ${SYSROOT} \
+    http://archive.debian.org/debian
+sudo cp /usr/bin/qemu-ppc-static ${SYSROOT}/usr/bin/
+sudo chroot ${SYSROOT} /debootstrap/debootstrap --second-stage
+
+sudo chroot ${SYSROOT} /bin/bash -c "apt update && apt install -y --force-yes zlib1g-dev build-essential vim file"

--- a/test/big_endian/run_test.sh
+++ b/test/big_endian/run_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+SYSROOT=${HOME}/powerpc_sysroot
+TEST_FILE=${SYSROOT}/test.txt
+
+sudo rm -f ${TEST_FILE} ${SYSROOT}/test.txt.gz
+sudo chroot ${SYSROOT} ./zstream-cpp/test/output_test
+sudo chroot ${SYSROOT} gunzip ./test.txt.gz


### PR DESCRIPTION
https://en.wikipedia.org/wiki/ZIP_(file_format) requires the file header to be in little endian format.  This PR forces the crc and size fields of the file header to always be in little endian format.

See https://github.com/harold-zetier/zstream-cpp/blob/fix-big-endian-issue/test/big_endian/README.md for setting up a local big endian environment for testing.  The testing environment is Ubuntu 22.04.

This closes https://github.com/geromueller/zstream-cpp/issues/5